### PR TITLE
use tdnf instead of apt-get in mariner

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -68,8 +68,7 @@ ENV PYPI_SERVER_VERSION=${PYPI_SERVER_VERSION}
 ENV PYPISERVER_PORT=${PYPISERVER_PORT}
 
 # Install ca-certificates
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates
+RUN tdnf install -y ca-certificates
 
 # Flush logs immediately to stdout
 ENV PYTHONUNBUFFERED=t


### PR DESCRIPTION
Forgot that mariner uses tdnf.